### PR TITLE
Support for maps and lists in metadata

### DIFF
--- a/lib/logger_humio_backend/metadata.ex
+++ b/lib/logger_humio_backend/metadata.ex
@@ -12,8 +12,8 @@ defmodule Logger.Backend.Humio.Metadata do
   def metadata_to_map(metadata, keys) do
     metadata
     |> take_metadata(keys)
-    |> metadata()
     |> Iteraptor.to_flatmap()
+    |> metadata()
     |> Enum.map(&nil_to_string/1)
     |> Enum.into(%{})
   end
@@ -38,7 +38,7 @@ defmodule Logger.Backend.Humio.Metadata do
     |> Keyword.drop(keys)
   end
 
-  def metadata(metadata) when is_list(metadata) do
+  def metadata(metadata) when is_map(metadata) do
     metadata
     |> Enum.map(fn {k, v} -> {k, metadata(k, v)} end)
   end
@@ -67,10 +67,6 @@ defmodule Logger.Backend.Humio.Metadata do
 
   defp metadata(:file, file) when is_list(file), do: file
 
-  defp metadata(:domain, [head | tail]) when is_atom(head) do
-    Enum.map_intersperse([head | tail], ?., &Atom.to_string/1)
-  end
-
   defp metadata(:mfa, {mod, fun, arity})
        when is_atom(mod) and is_atom(fun) and is_integer(arity) do
     Exception.format_mfa(mod, fun, arity)
@@ -80,8 +76,6 @@ defmodule Logger.Backend.Humio.Metadata do
        when is_atom(mod) and is_atom(fun) and is_integer(arity) do
     Exception.format_mfa(mod, fun, arity)
   end
-
-  defp metadata(_, list) when is_list(list), do: nil
 
   defp metadata(_, other) do
     case String.Chars.impl_for(other) do

--- a/test/logger_humio_backend/ingest_api/structured_test.exs
+++ b/test/logger_humio_backend/ingest_api/structured_test.exs
@@ -107,9 +107,7 @@ defmodule Logger.Humio.Backend.IngestApi.StructuredTest do
   # Should eventually figure out what to do with them.
   test "Metadata that cannot be encoded is submitted with nil value", %{ref: ref} do
     Logger.metadata(tuple: {"item1", "item2"})
-    Logger.metadata(list: ["item1", "item2"])
     Logger.metadata(some_function: &Enum.map/2)
-    Logger.metadata(map: %{bool: true, integer: 14})
     port = Port.open({:spawn, "cat"}, [:binary])
     Logger.metadata(port: port)
     Logger.info("message")
@@ -122,9 +120,7 @@ defmodule Logger.Humio.Backend.IngestApi.StructuredTest do
                  %{
                    "attributes" => %{
                      "tuple" => "nil",
-                     "list" => "nil",
                      "some_function" => "nil",
-                     "map" => "nil",
                      "port" => "nil"
                    }
                  }


### PR DESCRIPTION
Maps are flattened:

`Logger.metadata(some_map: %{a: 1, b: 2}` leads to

```
"some_map.a" => "1"
"some_map.b" => "2"
```

being sent to Humio, and

`Logger.metadata(some_list: [3, 4])` leads to

```
"some_list.0" => "3"
"some_list.1" => "4"
```