### PR TITLE
Plug for logging connection metadata

### DIFF
--- a/lib/logger_humio_backend/plug.ex
+++ b/lib/logger_humio_backend/plug.ex
@@ -21,28 +21,56 @@ defmodule Logger.Backend.Humio.Plug do
     start = System.monotonic_time()
 
     Conn.register_before_send(conn, fn conn ->
-      metadata = metadata(conn, start, keys)
+      metadata = to_metadata(conn, start)
       message = format_message(metadata)
-      Logger.log(level, message, metadata(conn, start, keys))
+      Logger.log(level, message, conn: Metadata.take_metadata(metadata, keys))
       conn
     end)
   end
 
-  defp format_message(_metadata) do
-    "great success"
+  defp format_message(metadata) do
+    response_time = Keyword.get(metadata, :response_time_us)
+    status = Keyword.get(metadata, :status)
+    request_path = Keyword.get(metadata, :request_path)
+    method = Keyword.get(metadata, :method)
+
+    [
+      method,
+      " ",
+      request_path,
+      " Sent ",
+      Integer.to_string(status),
+      " in ",
+      Integer.to_string(response_time),
+      "us"
+    ]
   end
 
-  defp metadata(conn, start, keys) do
+  defp to_metadata(conn, start) do
     stop = System.monotonic_time()
     diff = System.convert_time_unit(stop - start, :native, :microsecond)
 
-    [response_time_us: diff] ++ [conn: to_metadata(conn, keys)]
+    conn_metadata =
+      conn
+      |> Map.from_struct()
+      |> Enum.into([])
+      |> format_metadata()
+
+    [response_time_us: diff] ++ conn_metadata
   end
 
-  defp to_metadata(conn, keys) do
-    conn
-    |> Map.from_struct()
-    |> Enum.into([])
-    |> Metadata.take_metadata(keys)
+  # Puts certain fields into a more legible format. Separate from Metadata.format_metadata since certain fields we only see here
+  defp format_metadata(metadata) do
+    Iteraptor.map(metadata, fn {k, v} -> {k, metadata(k, v)} end)
+  end
+
+  defp metadata([:remote_ip], ip) do
+    ip
+    |> Tuple.to_list()
+    |> Enum.join(".")
+  end
+
+  defp metadata(_, other) do
+    other
   end
 end

--- a/lib/logger_humio_backend/plug.ex
+++ b/lib/logger_humio_backend/plug.ex
@@ -8,7 +8,7 @@ defmodule Logger.Backend.Humio.Plug do
   @behaviour Plug
 
   @default_level :info
-  @default_metadata [:method, :remote_ip, :request_path, :status]
+  @default_metadata [:method, :remote_ip, :request_path, :status, :response_time_us]
 
   def init(opts) do
     opts
@@ -59,7 +59,8 @@ defmodule Logger.Backend.Humio.Plug do
     [response_time_us: diff] ++ conn_metadata
   end
 
-  # Puts certain fields into a more legible format. Separate from Metadata.format_metadata since certain fields we only see here
+  # Puts certain fields into a more legible format.
+  # Separate from Metadata.format_metadata since certain fields we only see here
   defp format_metadata(metadata) do
     Iteraptor.map(metadata, fn {k, v} -> {k, metadata(k, v)} end)
   end

--- a/lib/logger_humio_backend/plug.ex
+++ b/lib/logger_humio_backend/plug.ex
@@ -7,34 +7,42 @@ defmodule Logger.Backend.Humio.Plug do
   alias Plug.Conn
   @behaviour Plug
 
+  @default_level :info
+  @default_metadata [:method, :remote_ip, :request_path, :status]
+
   def init(opts) do
     opts
   end
 
   def call(conn, opts) do
-    level = Keyword.get(opts, :level, :info)
-    keys = Keyword.get(opts, :metadata, :all)
-    message = Keyword.get(opts, :message, "Processed Request")
+    level = Keyword.get(opts, :level, @default_level)
+    keys = Keyword.get(opts, :metadata, @default_metadata)
 
     start = System.monotonic_time()
 
     Conn.register_before_send(conn, fn conn ->
+      metadata = metadata(conn, start, keys)
+      message = format_message(metadata)
       Logger.log(level, message, metadata(conn, start, keys))
       conn
     end)
   end
 
-  def metadata(conn, start, keys) do
+  defp format_message(_metadata) do
+    "great success"
+  end
+
+  defp metadata(conn, start, keys) do
     stop = System.monotonic_time()
     diff = System.convert_time_unit(stop - start, :native, :microsecond)
 
-    ([response_time_us: diff] ++ to_metadata(conn))
-    |> Metadata.take_metadata(keys)
+    [response_time_us: diff] ++ [conn: to_metadata(conn, keys)]
   end
 
-  defp to_metadata(conn) do
+  defp to_metadata(conn, keys) do
     conn
     |> Map.from_struct()
     |> Enum.into([])
+    |> Metadata.take_metadata(keys)
   end
 end

--- a/lib/logger_humio_backend/plug.ex
+++ b/lib/logger_humio_backend/plug.ex
@@ -15,7 +15,7 @@ defmodule Logger.Backend.Humio.Plug do
   end
 
   def call(conn, opts) do
-    level = Keyword.get(opts, :level, @default_level)
+    level = Keyword.get(opts, :log, @default_level)
     keys = Keyword.get(opts, :metadata, @default_metadata)
 
     start = System.monotonic_time()

--- a/test/logger_humio_backend/ingest_api/structured_test.exs
+++ b/test/logger_humio_backend/ingest_api/structured_test.exs
@@ -3,7 +3,7 @@ defmodule Logger.Humio.Backend.IngestApi.StructuredTest do
 
   import Mox
 
-  alias Logger.Backend.Humio.{Client, IngestApi}
+  alias Logger.Backend.Humio.{Client, IngestApi, TestStruct}
 
   require Logger
 
@@ -97,6 +97,7 @@ defmodule Logger.Humio.Backend.IngestApi.StructuredTest do
       Logger.metadata(string: "some string")
       Logger.metadata(map: %{"map_key" => "map_value"})
       Logger.metadata(list: ["list_entry_1", "list_entry_2"])
+      Logger.metadata(struct: %TestStruct{})
       pid = self()
       pid_string = :erlang.pid_to_list(pid) |> to_string()
       Logger.metadata(pid: pid)
@@ -109,6 +110,7 @@ defmodule Logger.Humio.Backend.IngestApi.StructuredTest do
       function = &Enum.map/2
       function_string = function |> :erlang.fun_to_list() |> to_string()
       Logger.metadata(function: function)
+      Logger.metadata(tuple: {:ok, "value"})
       Logger.info("message")
 
       assert_receive({^ref, %{body: body, base_url: @base_url, path: @path, headers: @headers}})
@@ -127,27 +129,9 @@ defmodule Logger.Humio.Backend.IngestApi.StructuredTest do
                        "map" => %{"map_key" => "map_value"},
                        "list" => ["list_entry_1", "list_entry_2"],
                        "port" => ^port_string,
-                       "function" => ^function_string
-                     }
-                   }
-                 ]
-               }
-             ] = Jason.decode!(body)
-    end
-
-    # Should eventually figure out what to do with them.
-    test "Metadata that cannot be encoded is submitted with nil value", %{ref: ref} do
-      Logger.metadata(tuple: {"item1", "item2"})
-      Logger.info("message")
-
-      assert_receive({^ref, %{body: body, base_url: @base_url, path: @path, headers: @headers}})
-
-      assert [
-               %{
-                 "events" => [
-                   %{
-                     "attributes" => %{
-                       "tuple" => "nil"
+                       "function" => ^function_string,
+                       "struct" => %{"name" => "John", "age" => "27"},
+                       "tuple" => ["ok", "value"]
                      }
                    }
                  ]

--- a/test/logger_humio_backend/plug_test.exs
+++ b/test/logger_humio_backend/plug_test.exs
@@ -86,7 +86,7 @@ defmodule Logger.Backend.Humio.PlugTest do
                          "private" => %{},
                          "query_params" => %{"aspect" => "query_params"},
                          "query_string" => "",
-                         "remote_ip" => ["127", "0", "0", "1"],
+                         "remote_ip" => "127.0.0.1",
                          "req_cookies" => %{"aspect" => "cookies"},
                          "req_headers" => [],
                          "request_path" => "/",
@@ -102,22 +102,21 @@ defmodule Logger.Backend.Humio.PlugTest do
                          "status" => "200"
                        }
                      },
-                     "rawstring" => "[info] great success",
+                     "rawstring" => rawstring,
                      "timestamp" => _
                    }
                  ]
                }
              ] = decoded_body
+
+      assert rawstring =~ "[info] GET / Sent 200 in"
     end
 
     test " prints a little bit of metadata, as a treat", %{ref: ref} do
-      message = "great success"
-
       conn(:get, "/")
       |> call(
         log_level: :info,
-        metadata: [:method, :remote_ip, :request_path, :status],
-        message: message
+        metadata: [:method, :remote_ip, :request_path, :status]
       )
       |> send_resp(200, "response_body")
 
@@ -133,16 +132,18 @@ defmodule Logger.Backend.Humio.PlugTest do
                        "conn" => %{
                          "method" => "GET",
                          "request_path" => "/",
-                         "remote_ip" => ["127", "0", "0", "1"],
+                         "remote_ip" => "127.0.0.1",
                          "status" => "200"
                        }
                      },
-                     "rawstring" => "[info] great success",
+                     "rawstring" => rawstring,
                      "timestamp" => _
                    }
                  ]
                }
              ] = decoded_body
+
+      assert rawstring =~ "[info] GET / Sent 200 in"
     end
   end
 

--- a/test/logger_humio_backend/plug_test.exs
+++ b/test/logger_humio_backend/plug_test.exs
@@ -54,6 +54,7 @@ defmodule Logger.Backend.Humio.PlugTest do
                    %{
                      "attributes" => %{
                        "conn" => %{
+                         "response_time_us" => _,
                          "adapter" => [
                            "Plug.Adapters.Test.Conn",
                            %{
@@ -114,10 +115,7 @@ defmodule Logger.Backend.Humio.PlugTest do
 
     test " prints a little bit of metadata, as a treat", %{ref: ref} do
       conn(:get, "/")
-      |> call(
-        log_level: :info,
-        metadata: [:method, :remote_ip, :request_path, :status]
-      )
+      |> call([])
       |> send_resp(200, "response_body")
 
       assert_receive {^ref, %{body: body}}
@@ -133,7 +131,8 @@ defmodule Logger.Backend.Humio.PlugTest do
                          "method" => "GET",
                          "request_path" => "/",
                          "remote_ip" => "127.0.0.1",
-                         "status" => "200"
+                         "status" => "200",
+                         "response_time_us" => _
                        }
                      },
                      "rawstring" => rawstring,

--- a/test/logger_humio_backend/plug_test.exs
+++ b/test/logger_humio_backend/plug_test.exs
@@ -41,7 +41,7 @@ defmodule Logger.Backend.Humio.PlugTest do
       message = "great success"
 
       conn(:get, "/")
-      |> call(log_level: :info, metadata: :all, message: message)
+      |> call(metadata: :all)
       |> send_resp(200, "response_body")
 
       assert_receive {^ref, %{body: body}}

--- a/test/logger_humio_backend_test.exs
+++ b/test/logger_humio_backend_test.exs
@@ -163,7 +163,7 @@ defmodule Logger.Backend.Humio.Test do
       # we multiply by 0.7 to ensure we're under the threshold introduced by the 20% jitter.
       refute_receive({^ref, %{}}, round(flush_interval_ms * 0.7))
 
-      # we multipley by 0.5 so that we assert the :transmit is received between 0.7 to 1.3 the flush interval,
+      # we multiply by 0.5 so that we assert the :transmit is received between 0.7 to 1.3 the flush interval,
       # which accounts for the 20% jitter.
       assert_receive(
         {^ref, %{log_events: [%{message: "message"}]}},

--- a/test/support/test_struct.ex
+++ b/test/support/test_struct.ex
@@ -1,0 +1,6 @@
+defmodule Logger.Backend.Humio.TestStruct do
+  @moduledoc """
+  A test struct used to illustrate the ability to submit a struct as metadata value.
+  """
+  defstruct name: "John", age: 27
+end


### PR DESCRIPTION
Splits out logs that look like

```
host[<0.20757.0>]: [info]  POST /my/path Sent 204 in 10752us
```

Ships all sorts of Plug.Conn fields as metadata, fully configurable, with sensible defaults.

Drop-in replacement for Plug.Logger
