### PR TITLE
Better independent testing

### DIFF
--- a/lib/logger_humio_backend.ex
+++ b/lib/logger_humio_backend.ex
@@ -8,17 +8,6 @@ defmodule Logger.Backend.Humio do
 
   require Logger
 
-  # "advertised" options
-  @default_level :debug
-  @default_metadata []
-  @default_max_batch_size 20
-  @default_flush_interval_ms 2_000
-  @default_debug_io_device :stdio
-
-  # used primarily for testing
-  @default_client Client.Tesla
-  @default_ingest_api IngestApi.Structured
-
   @type log_event :: %{
           level: atom(),
           message: String.t(),
@@ -202,43 +191,41 @@ defmodule Logger.Backend.Humio do
     IO.puts(io_device, [level, ": ", message])
   end
 
+  def default_config() do
+    [
+      # used primarily for testing
+      client: Client.Tesla,
+      ingest_api: IngestApi.Structured,
+      iso8601_format_fun: TimeFormat.iso8601_format_fun(),
+      # "advertised" options
+      host: "",
+      token: "",
+      level: :debug,
+      metadata: [],
+      format: nil,
+      max_batch_size: 20,
+      flush_interval_ms: 2_000,
+      debug_io_device: :stdio,
+      fields: %{},
+      tags: %{}
+    ]
+  end
+
   defp configure(name, opts) do
     env = Application.get_env(:logger, name, [])
     opts = Keyword.merge(env, opts)
     Application.put_env(:logger, name, opts)
 
-    host = Keyword.get(opts, :host, "")
-    token = token(Keyword.get(opts, :token, ""))
-
-    ingest_api = Keyword.get(opts, :ingest_api, @default_ingest_api)
-    client = Keyword.get(opts, :client, @default_client)
-    level = Keyword.get(opts, :level, @default_level)
-    metadata = Keyword.get(opts, :metadata, @default_metadata)
-    format = opts |> Keyword.get(:format, nil) |> Formatter.compile()
-    max_batch_size = Keyword.get(opts, :max_batch_size, @default_max_batch_size)
-    flush_interval_ms = Keyword.get(opts, :flush_interval_ms, @default_flush_interval_ms)
-    debug_io_device = Keyword.get(opts, :debug_io_device, @default_debug_io_device)
-    iso8601_format_fun = TimeFormat.iso8601_format_fun()
-    fields = Keyword.get(opts, :fields, %{})
-    tags = Keyword.get(opts, :tags, %{})
+    config =
+      default_config()
+      |> Keyword.merge(opts)
+      |> Keyword.put_new(:name, name)
+      |> Keyword.update!(:format, fn format -> Formatter.compile(format) end)
+      |> Keyword.update!(:token, fn token -> token(token) end)
+      |> Enum.into(Map.new())
 
     %{
-      config: %{
-        token: token,
-        host: host,
-        name: name,
-        ingest_api: ingest_api,
-        client: client,
-        level: level,
-        format: format,
-        metadata: metadata,
-        max_batch_size: max_batch_size,
-        flush_interval_ms: flush_interval_ms,
-        debug_io_device: debug_io_device,
-        iso8601_format_fun: iso8601_format_fun,
-        fields: fields,
-        tags: tags
-      },
+      config: config,
       log_events: [],
       flush_timer: nil
     }

--- a/lib/logger_humio_backend.ex
+++ b/lib/logger_humio_backend.ex
@@ -191,7 +191,7 @@ defmodule Logger.Backend.Humio do
     IO.puts(io_device, [level, ": ", message])
   end
 
-  def default_config() do
+  def default_config do
     [
       # used primarily for testing
       client: Client.Tesla,

--- a/test/logger_humio_backend/formatter_test.exs
+++ b/test/logger_humio_backend/formatter_test.exs
@@ -3,12 +3,9 @@ defmodule Logger.Backend.Humio.FormatterTest do
 
   import Mox
 
-  alias Logger.Backend.Humio.{Client, IngestApi}
+  alias Logger.Backend.Humio.{Client, ConfigHelpers}
 
   require Logger
-
-  @backend {Logger.Backend.Humio, :test}
-  Logger.add_backend(@backend)
 
   @base_url "humio.url"
   @token "token"
@@ -24,15 +21,11 @@ defmodule Logger.Backend.Humio.FormatterTest do
       @happy_result
     end)
 
-    config(
+    ConfigHelpers.configure(
       client: Client.Mock,
-      ingest_api: IngestApi.Structured,
       host: @base_url,
       token: @token,
-      # use default format
-      format: nil,
-      max_batch_size: 1,
-      metadata: []
+      max_batch_size: 1
     )
 
     {:ok, %{ref: ref}}
@@ -50,9 +43,5 @@ defmodule Logger.Backend.Humio.FormatterTest do
     assert decoded_message =~ "[info]"
     assert decoded_message =~ self() |> :erlang.pid_to_list() |> (&"[#{&1}]").()
     verify!()
-  end
-
-  defp config(opts) do
-    :ok = Logger.configure_backend(@backend, opts)
   end
 end

--- a/test/logger_humio_backend/ingest_api/structured_test.exs
+++ b/test/logger_humio_backend/ingest_api/structured_test.exs
@@ -3,12 +3,9 @@ defmodule Logger.Humio.Backend.IngestApi.StructuredTest do
 
   import Mox
 
-  alias Logger.Backend.Humio.{Client, IngestApi, TestStruct}
+  alias Logger.Backend.Humio.{Client, ConfigHelpers, TestStruct}
 
   require Logger
-
-  @backend {Logger.Backend.Humio, :test}
-  Logger.add_backend(@backend)
 
   @base_url "humio.url"
   @token "token"
@@ -33,8 +30,7 @@ defmodule Logger.Humio.Backend.IngestApi.StructuredTest do
       @happy_result
     end)
 
-    config(
-      ingest_api: IngestApi.Structured,
+    ConfigHelpers.configure(
       client: Client.Mock,
       host: @base_url,
       format: "$message",
@@ -138,9 +134,5 @@ defmodule Logger.Humio.Backend.IngestApi.StructuredTest do
                }
              ] = Jason.decode!(body)
     end
-  end
-
-  defp config(opts) do
-    :ok = Logger.configure_backend(@backend, opts)
   end
 end

--- a/test/logger_humio_backend/plug_test.exs
+++ b/test/logger_humio_backend/plug_test.exs
@@ -4,12 +4,9 @@ defmodule Logger.Backend.Humio.PlugTest do
 
   import Mox
 
-  alias Logger.Backend.Humio.{Client, IngestApi, Plug}
+  alias Logger.Backend.Humio.{Client, ConfigHelpers, Plug}
 
   require Logger
-
-  @backend {Logger.Backend.Humio, :test}
-  Logger.add_backend(@backend)
 
   @happy_result {:ok, %{status: 200, body: "somebody"}}
 
@@ -23,9 +20,8 @@ defmodule Logger.Backend.Humio.PlugTest do
       @happy_result
     end)
 
-    config(
+    ConfigHelpers.configure(
       client: Client.Mock,
-      ingest_api: IngestApi.Structured,
       format: "[$level] $message\n",
       max_batch_size: 1,
       metadata: [:conn]
@@ -146,9 +142,5 @@ defmodule Logger.Backend.Humio.PlugTest do
 
   defp call(conn, opts) do
     Plug.call(conn, Plug.init(opts))
-  end
-
-  defp config(opts) do
-    :ok = Logger.configure_backend(@backend, opts)
   end
 end

--- a/test/support/config_helpers.ex
+++ b/test/support/config_helpers.ex
@@ -1,0 +1,15 @@
+defmodule Logger.Backend.Humio.ConfigHelpers do
+  @moduledoc """
+  Helper for configuring a Logger Backend for tests that is completely independent from test to test, as we grab the default_config and then merge in the provided opts.
+  """
+
+  alias Logger.Backend.Humio
+
+  @backend {Logger.Backend.Humio, :test}
+
+  def configure(opts) do
+    Logger.add_backend(@backend)
+    opts = Keyword.merge(Humio.default_config(), opts)
+    :ok = Logger.configure_backend(@backend, opts)
+  end
+end


### PR DESCRIPTION
Since the Logger is core functionality, and the logger puts its
configuration in the env, we are creating a helper function for
resetting the backend to a known default state into which we merge the
provided configuration options.

