### PR TITLE
Use :inet.ntoa/1 to format IP addresses

### DIFF
--- a/lib/logger_humio_backend/plug.ex
+++ b/lib/logger_humio_backend/plug.ex
@@ -60,9 +60,10 @@ defmodule Logger.Backend.Humio.Plug do
   end
 
   defp metadata(:remote_ip, ip) do
-    ip
-    |> Tuple.to_list()
-    |> Enum.join(".")
+    case :inet.ntoa(ip) do
+      {:error, :einval} -> nil
+      chars -> to_string(chars)
+    end
   end
 
   defp metadata(_, other) do

--- a/test/logger_humio_backend/plug_test.exs
+++ b/test/logger_humio_backend/plug_test.exs
@@ -141,7 +141,7 @@ defmodule Logger.Backend.Humio.PlugTest do
 
     test "formats the remote IP correctly for v6 addresses", %{ref: ref} do
       conn(:get, "/")
-      |> Map.put(:remote_ip, {8193, 3512, 15437, 21, 0, 0, 6703, 6699})
+      |> Map.put(:remote_ip, {8193, 3512, 15_437, 21, 0, 0, 6703, 6699})
       |> call([])
       |> send_resp(200, "response_body")
 

--- a/test/logger_humio_backend/plug_test.exs
+++ b/test/logger_humio_backend/plug_test.exs
@@ -138,6 +138,31 @@ defmodule Logger.Backend.Humio.PlugTest do
 
       assert rawstring =~ "[info] GET / Sent 200"
     end
+
+    test "formats the remote IP correctly for v6 addresses", %{ref: ref} do
+      conn(:get, "/")
+      |> Map.put(:remote_ip, {8193, 3512, 15437, 21, 0, 0, 6703, 6699})
+      |> call([])
+      |> send_resp(200, "response_body")
+
+      assert_receive {^ref, %{body: body}}
+
+      decoded_body = Jason.decode!(body)
+
+      assert [
+               %{
+                 "events" => [
+                   %{
+                     "attributes" => %{
+                       "conn" => %{
+                         "remote_ip" => "2001:db8:3c4d:15::1a2f:1a2b"
+                       }
+                     }
+                   }
+                 ]
+               }
+             ] = decoded_body
+    end
   end
 
   defp call(conn, opts) do


### PR DESCRIPTION
This ensures that we don't format v6 addresses incorrectly. Before this change,
the v6 address "2001:db8:3c4d:15::1a2f:1a2b" would have been formatted as
"8193.3512.15437.21.0.0.6703.6699".